### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/sanic/config.py
+++ b/sanic/config.py
@@ -183,7 +183,7 @@ class Config(dict):
                 exec(compile(config_file.read(), filename, 'exec'),
                      module.__dict__)
         except IOError as e:
-            e.strerror = 'Unable to load configuration file (%s)' % e.strerror
+            e.strerror = 'Unable to load configuration file ({0!s})'.format(e.strerror)
             raise
         self.from_object(module)
         return True

--- a/sanic/cookies.py
+++ b/sanic/cookies.py
@@ -10,7 +10,7 @@ import string
 _LegalChars = string.ascii_letters + string.digits + "!#$%&'*+-.^_`|~:"
 _UnescapedChars = _LegalChars + ' ()/<=>?@[]{}'
 
-_Translator = {n: '\\%03o' % n
+_Translator = {n: '\\{0:03o}'.format(n)
                for n in set(range(256)) - set(map(ord, _UnescapedChars))}
 _Translator.update({
     ord('"'): '\\"',
@@ -30,7 +30,7 @@ def _quote(str):
         return '"' + str.translate(_Translator) + '"'
 
 
-_is_legal_key = re.compile('[%s]+' % re.escape(_LegalChars)).fullmatch
+_is_legal_key = re.compile('[{0!s}]+'.format(re.escape(_LegalChars))).fullmatch
 
 # ------------------------------------------------------------ #
 #  Custom SimpleCookie
@@ -101,26 +101,26 @@ class Cookie(dict):
         return super().__setitem__(key, value)
 
     def encode(self, encoding):
-        output = ['%s=%s' % (self.key, _quote(self.value))]
+        output = ['{0!s}={1!s}'.format(self.key, _quote(self.value))]
         for key, value in self.items():
             if key == 'max-age':
                 try:
-                    output.append('%s=%d' % (self._keys[key], value))
+                    output.append('{0!s}={1:d}'.format(self._keys[key], value))
                 except TypeError:
-                    output.append('%s=%s' % (self._keys[key], value))
+                    output.append('{0!s}={1!s}'.format(self._keys[key], value))
             elif key == 'expires':
                 try:
-                    output.append('%s=%s' % (
+                    output.append('{0!s}={1!s}'.format(
                         self._keys[key],
                         value.strftime("%a, %d-%b-%Y %T GMT")
                     ))
                 except AttributeError:
-                    output.append('%s=%s' % (self._keys[key], value))
+                    output.append('{0!s}={1!s}'.format(self._keys[key], value))
             elif key in self._flags:
                 if self[key]:
                     output.append(self._keys[key])
             else:
-                output.append('%s=%s' % (self._keys[key], value))
+                output.append('{0!s}={1!s}'.format(self._keys[key], value))
 
         return "; ".join(output).encode(encoding)
 

--- a/sanic/exceptions.py
+++ b/sanic/exceptions.py
@@ -168,7 +168,7 @@ class ContentRangeError(SanicException):
         super().__init__(message)
         self.headers = {
             'Content-Type': 'text/plain',
-            "Content-Range": "bytes */%s" % (content_range.total,)
+            "Content-Range": "bytes */{0!s}".format(content_range.total)
         }
 
 

--- a/sanic/handlers.py
+++ b/sanic/handlers.py
@@ -135,18 +135,18 @@ class ContentRangeHandler:
         unit, _, value = tuple(map(str.strip, _range.partition('=')))
         if unit != 'bytes':
             raise InvalidRangeType(
-                '%s is not a valid Range Type' % (unit,), self)
+                '{0!s} is not a valid Range Type'.format(unit), self)
         start_b, _, end_b = tuple(map(str.strip, value.partition('-')))
         try:
             self.start = int(start_b) if start_b else None
         except ValueError:
             raise ContentRangeError(
-                '\'%s\' is invalid for Content Range' % (start_b,), self)
+                '\'{0!s}\' is invalid for Content Range'.format(start_b), self)
         try:
             self.end = int(end_b) if end_b else None
         except ValueError:
             raise ContentRangeError(
-                '\'%s\' is invalid for Content Range' % (end_b,), self)
+                '\'{0!s}\' is invalid for Content Range'.format(end_b), self)
         if self.end is None:
             if self.start is None:
                 raise ContentRangeError(
@@ -164,7 +164,7 @@ class ContentRangeHandler:
                 'Invalid for Content Range parameters', self)
         self.size = self.end - self.start
         self.headers = {
-            'Content-Range': "bytes %s-%s/%s" % (
+            'Content-Range': "bytes {0!s}-{1!s}/{2!s}".format(
                 self.start, self.end, self.total)}
 
     def __bool__(self):

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -159,5 +159,5 @@ def test_static_content_range_error(file_name, static_file_directory):
     assert response.status == 416
     assert 'Content-Length' in response.headers
     assert 'Content-Range' in response.headers
-    assert response.headers['Content-Range'] == "bytes */%s" % (
-        len(get_file_content(static_file_directory, file_name)),)
+    assert response.headers['Content-Range'] == "bytes */{0!s}".format(
+        len(get_file_content(static_file_directory, file_name)))


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:stopspazzing:sanic?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:stopspazzing:sanic?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)